### PR TITLE
fix `gem build` failing

### DIFF
--- a/prowl.gemspec
+++ b/prowl.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
     "lib/prowl.rb",
     "prowl.gemspec",
     "Rakefile",
-    "README",
+    "README.md",
     "test/prowl_test.rb"
   ]
 end


### PR DESCRIPTION
gem build failed due to "README" not being found, updated to README.md
